### PR TITLE
Update to 2.7 version of Spacewalk and fixes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,14 +10,14 @@ provisioner:
   data_bags_path: test/fixtures/data_bags
 
 platforms:
-- name: centos-6.6
+- name: centos-6.9
   driver_config:
-    image: centos:6.6
+    image: centos:6.9
     platform: centos
 
 suites:
 - name: default
-  run_list: 
+  run_list:
     - recipe[spacewalk-server]
     - recipe[spacewalk-server::iptables]
     - recipe[spacewalk-server::ubuntu]

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
 source 'https://rubygems.org'
 
 group :lint do
-  gem 'foodcritic', '~> 4.0.0'
-  gem 'rubocop', '~> 0.25.0'
-  gem 'rainbow', '< 2.0'
+  gem 'foodcritic'
+  gem 'rubocop'
+  gem 'rainbow'
   gem 'rake'
 end
 
 group :unit do
-  gem 'berkshelf', '~> 3.1'
-  gem 'chefspec',  '~> 4.0.2'
+  gem 'berkshelf'
+  gem 'chefspec'
 end
 
 group :kitchen_common do
-  gem 'test-kitchen', '~> 1.2'
+  gem 'test-kitchen'
   gem 'chef-zero'
 end
 
@@ -29,7 +29,7 @@ group :development do
   gem 'ruby_gntp'
   gem 'growl'
   gem 'rb-fsevent'
-  gem 'guard', '~> 2.6'
+  gem 'guard'
   gem 'guard-kitchen'
   # gem 'guard-foodcritic'
   gem 'guard-rspec'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,7 @@ default['spacewalk']['hostname'] = node['hostname']
 
 # Answer file configuration
 default['spacewalk']['server']['admin_email'] = 'root@localhost'
+default['spacewalk']['server']['ssl']['cnames'] = 'spacewalk2'
 default['spacewalk']['server']['ssl']['org'] = 'Spacewalk Org'
 default['spacewalk']['server']['ssl']['org_unit'] = 'spacewalk'
 default['spacewalk']['server']['ssl']['city'] = 'My City'
@@ -20,9 +21,9 @@ arch = node['kernel']['machine'] == 'x86_64' ? 'x86_64' : 'i386'
 case node['platform_family']
 when 'rhel'
   platform_major = node['platform_version'][0]
-  default['spacewalk']['server']['repo_url'] = "http://spacewalk.redhat.com/yum/2.6/RHEL/#{platform_major}/#{arch}/spacewalk-repo-2.6-0.el#{platform_major}.noarch.rpm"
+  default['spacewalk']['server']['repo_url'] = "http://yum.spacewalkproject.org/2.7/RHEL/#{platform_major}/#{arch}/spacewalk-repo-2.7-2.el#{platform_major}.noarch.rpm"
 when 'fedora'
-  default['spacewalk']['server']['repo_url'] = "http://spacewalk.redhat.com/yum/2.6/Fedora/#{node['platform_version']}/#{arch}/spacewalk-repo-2.6-0.fc#{node['platform_version']}.noarch.rpm"
+  default['spacewalk']['server']['repo_url'] = "http://yum.spacewalkproject.org/2.7/Fedora/#{node['platform_version']}/#{arch}/spacewalk-repo-2.7-2.fc#{node['platform_version']}.noarch.rpm"
 end
 
 case node['spacewalk']['server']['db']['type']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,13 +12,20 @@
 include_recipe 'yum-epel' if platform_family?('rhel')
 include_recipe 'yum-fedora' if platform_family?('fedora')
 
-yum_repository 'jpackage-generic' do
-  url 'http://mirrors.dotsrc.org/pub/jpackage/5.0/generic/free/'
-  mirrorlist 'http://www.jpackage.org/mirrorlist.php?dist=generic&type=free&release=5.0'
-  description 'JPackage Generic'
-  gpgkey 'http://www.jpackage.org/jpackage.asc'
-  enabled true
-  action :add
+remote_file '/etc/yum.repos.d/group_spacewalkproject-java-packages-epel-7.repo' do
+  source 'https://copr.fedorainfracloud.org/coprs/g/spacewalkproject/java-packages/repo/epel-7/group_spacewalkproject-java-packages-epel-7.repo'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end
+
+remote_file '/etc/yum.repos.d/group_spacewalkproject-epel6-addons-epel-6.repo' do
+  source 'https://copr.fedorainfracloud.org/coprs/g/spacewalkproject/epel6-addons/repo/epel-6/group_spacewalkproject-epel6-addons-epel-6.repo'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
 end
 
 remote_file "#{Chef::Config[:file_cache_path]}/spacewalk-repo.rpm" do

--- a/templates/default/spacewalk-answers.conf.erb
+++ b/templates/default/spacewalk-answers.conf.erb
@@ -1,4 +1,5 @@
 admin-email = <%= node['spacewalk']['server']['admin_email'] %>
+ssl-set-cnames = <%= node['spacewalk']['server']['ssl']['cnames'] %>
 ssl-set-org = <%= node['spacewalk']['server']['ssl']['org'] %>
 ssl-set-org-unit = <%= node['spacewalk']['server']['ssl']['org_unit'] %>
 ssl-set-city = <%= node['spacewalk']['server']['ssl']['city'] %>


### PR DESCRIPTION
- jpackage-generic repo is obsolete, the howto recommends installing group_spacewalkproject-java-packages
- yum repositories links updated to the right one: http://yum.spacewalkproject.org
- Spacewalk version updated to 2.7
- new parameters for the automatic answer file: ssl-set-cnames
- kitchen updated to latest centos 6.9
- gems should be the latest, if it breaks the code needs to be fixed 
